### PR TITLE
v4.3.1 - Alt+Rightclick Move

### DIFF
--- a/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_game.cfg
+++ b/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_game.cfg
@@ -37,7 +37,8 @@ dota_gamescom_althack "0"
 //Lock mouse in the window mode (Window mode).
 dota_mouse_window_lock "1"              
 
-
+//Alt+Rightclick to move in an accurate direction to prevent disasters
+dota_unit_allow_moveto_direction "1"
 
 ////////////////////////////////////////////////////////////
 //Interface related


### PR DESCRIPTION
Alt+Rightclick forces your hero to move in that Direction rather than the regular Rightclick which moves your hero to that point.

Example: http://www.twitch.tv/sing_sing/v/5094104?t=2h48m43s Sing trying to leap over trees using normal Rightclick movement. However, if he used Alt+Rightclick anywhere on this red line: http://i.imgur.com/Qbjs1ZU.jpg: he would be facing the appropriate direction for a safe leap.
TL;DR - Alt+Rightclick movement is incredibly useful to face proper directions in narrow positions, especially with Mirana's Leap, Shadowfriend's Razes, and Forcestaves.

Must be turned on through console
dota_unit_allow_moveto_direction 1

By this config "Alt" is the "`"

From Dota 2 Reddit